### PR TITLE
Add port check support to launch vm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM python:latest
 
-RUN apt-get -y update
-RUN apt-get -y install unzip jq
+RUN apt-get -y update &&  apt-get -y install unzip jq
 
 COPY src /project/src/
 COPY setup.py /project/
 
 WORKDIR /project
-RUN python setup.py bdist_wheel
-RUN pip install --no-cache-dir dist/*.whl
+RUN     python setup.py bdist_wheel && pip install --no-cache-dir dist/*.whl
+WORKDIR /scratch
 
 CMD pybot --version


### PR DESCRIPTION
The PR includes additional checks such that aws launch_vm does not return until port 22 is open on the target VM.