### PR TITLE
Add instance profile support to cloud provider

### DIFF
--- a/src/tortuga_test_lib/cloud_provider/aws.py
+++ b/src/tortuga_test_lib/cloud_provider/aws.py
@@ -34,6 +34,7 @@ class AwsLauncher(CloudProviderLauncher):
                   subnet_id: str,
                   image_id: str,
                   instance_type: str,
+                  instance_profile: str,
                   **kwargs) -> Tuple[str, str, str, str]:
         #
         # Build a unique identifier to use as the instance and key pair name
@@ -51,6 +52,9 @@ class AwsLauncher(CloudProviderLauncher):
         # Crate the instance
         #
         instance_list = ec2.create_instances(
+            IamInstanceProfile={
+                'Name' : instance_profile
+            },
             ImageId=image_id,
             InstanceType=instance_type,
             MinCount=1,

--- a/src/tortuga_test_lib/cloud_provider/base.py
+++ b/src/tortuga_test_lib/cloud_provider/base.py
@@ -22,6 +22,7 @@ class CloudProviderLauncher:
                   subnet_id: str,
                   image_id: str,
                   instance_type: str,
+                  instance_profile: str,
                   **kwargs) -> Tuple[str, str, str, str]:
         """
         Launches a VM instance.
@@ -31,6 +32,7 @@ class CloudProviderLauncher:
         :param str subnet_id:
         :param str image_id:
         :param str instance_type:
+        :param str instance_profile
         :param kwargs:
 
         :return Tuple[str, str, str, str]: a tuple containing the instance id,

--- a/src/tortuga_test_lib/robot/CloudProvider.py
+++ b/src/tortuga_test_lib/robot/CloudProvider.py
@@ -42,7 +42,7 @@ class CloudProvider:
 
     def launch_vm(self, provider: str, region: str, security_group_id: str,
                   subnet_id: str, image_id: str, instance_type: str,
-                  **kwargs) -> Tuple[str, str, str, str]:
+                  instance_profile: str, **kwargs) -> Tuple[str, str, str, str]:
         """
         Launches a VM instance.
 
@@ -52,6 +52,7 @@ class CloudProvider:
         :param str subnet_id:
         :param str image_id:
         :param str instance_type:
+        :param str instance_profile
         :param kwargs:
 
         :return Tuple[str, str, str, str]: a tuple containing the instance id,
@@ -62,7 +63,7 @@ class CloudProvider:
         launcher = self._get_launcher(provider)
 
         result = launcher.launch_vm(region, security_group_id, subnet_id,
-                                    image_id, instance_type, **kwargs)
+                                    image_id, instance_type, instance_profile, **kwargs)
         # Wait for the ssh port to be open
         if len(result) == 4 and result[1]:
             self.wait_for_port(result[1], 22, 40)


### PR DESCRIPTION
Tortuga needs an instance profile attached to the VM so that aws operations can be invoked without the need of passing credentials to the instance.